### PR TITLE
Connection revamp

### DIFF
--- a/src/core/modellib/cpp-meson-lib/BaseModel.cxx
+++ b/src/core/modellib/cpp-meson-lib/BaseModel.cxx
@@ -52,3 +52,8 @@ uint32_t meta_set(void* ptr, BufferStruct id, BufferStruct data) {
     BaseModel* app = (BaseModel*) ptr;
     return app->msg_set(id, data);
 }
+
+uint8_t* get_ptr(void* ptr, BufferStruct id) {
+    BaseModel* app = (BaseModel*) ptr;
+    return app->get_ptr(id);
+}

--- a/src/core/modellib/cpp-meson-lib/BaseModel.hxx
+++ b/src/core/modellib/cpp-meson-lib/BaseModel.hxx
@@ -26,6 +26,7 @@ public:
 
     virtual uint32_t msg_get(BufferStruct id, SizeCallback cb) = 0;
     virtual uint32_t msg_set(BufferStruct id, BufferStruct data) = 0;
+    virtual uint8_t* get_ptr(BufferStruct id) = 0;
 };
 
 void DeleteModel(BaseModel* obj);
@@ -34,6 +35,7 @@ extern "C" {
     bool c_ffi_interface(BaseModel* obj, void* ptrs[7]);
     uint32_t meta_get(void* ptr, BufferStruct id, SizeCallback cb);
     uint32_t meta_set(void* ptr, BufferStruct id, BufferStruct data);
+    uint8_t* get_ptr(void* ptr, BufferStruct id);
 }
 
 #endif

--- a/src/core/modellib/src/lib.rs
+++ b/src/core/modellib/src/lib.rs
@@ -27,6 +27,7 @@ pub trait BaseModel {
 
     fn msg_get(&self, id : BufferStruct, cb : SizeCallback) -> u32;
     fn msg_set(&mut self, id : BufferStruct, data : BufferStruct) -> u32;
+    fn get_ptr(&self, id : BufferStruct) -> *const u8;
 }
 
 
@@ -63,6 +64,9 @@ impl BaseModel for BaseModelExternal {
     fn msg_set(&mut self, _id : BufferStruct, _data : BufferStruct) -> u32 {
         1
     }
+    fn get_ptr(&self, _id : BufferStruct) -> *const u8 {
+        0 as *const u8
+    }
 }
 
 impl Drop for BaseModelExternal {
@@ -87,4 +91,11 @@ pub extern "C" fn meta_set(ptr : *mut c_void, id : BufferStruct, data : BufferSt
     let stat = (*app).msg_set(id, data);
     Box::into_raw(app); // release ownership of the box
     stat
+}
+#[no_mangle]
+pub extern "C" fn get_ptr(ptr : *mut c_void, id : BufferStruct) -> *const u8 {
+    let app : Box<Box<dyn BaseModel + Send>> = unsafe { Box::from_raw(ptr as *mut Box<dyn BaseModel + Send>) };
+    let p = (*app).get_ptr(id);
+    Box::into_raw(app); // release ownership of the box
+    p
 }

--- a/src/core/src/connection.rs
+++ b/src/core/src/connection.rs
@@ -46,6 +46,9 @@ impl BaseModel for Connection {
     fn msg_set(&mut self, _id : BufferStruct, _data : BufferStruct) -> u32 {
         1
     }
+    fn get_ptr(&self, _id : BufferStruct) -> *const u8 {
+        0 as *const u8
+    }
 }
 
 unsafe impl Send for Connection {}

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -110,7 +110,7 @@ pub extern "C" fn add_model_by_callbacks(thread: i64,
 }
 
 #[no_mangle]
-pub extern "C" fn add_connection(src: *mut c_void, dst: *mut c_void, size: usize, thread: i64, divisor: i64, offset: i64) -> u32 {
+pub extern "C" fn add_connection(src: *mut u8, dst: *mut u8, size: usize, thread: i64, divisor: i64, offset: i64) -> u32 {
     if src.is_null() || dst.is_null() || size == 0 {
         return RSISStat::BADARG as u32;
     }

--- a/src/templates/header_cpp.template
+++ b/src/templates/header_cpp.template
@@ -10,5 +10,6 @@
 
 uint32_t handle_msg_get(const {{NAME}}& interface, BufferStruct id, SizeCallback cb);
 uint32_t handle_msg_set({{NAME}}& interface, BufferStruct id, BufferStruct data);
+uint8_t* get_pointer({{NAME}}& interface, BufferStruct id);
 
 #endif // __{{HEADER_GUARD}}__

--- a/src/templates/rust.template
+++ b/src/templates/rust.template
@@ -14,12 +14,12 @@ use std::slice::Iter;
 {{CONSTRUCTOR_DEFINITIONS}}
 
 {{SERIALIZATION}}
-
 {{DESERIALIZATION}}
+{{POINTER}}
 
 pub fn handle_msg_get(interface : &{{NAME}}, id : BufferStruct, cb : SizeCallback) -> u32 {
     let indices = unsafe { std::slice::from_raw_parts(id.ptr as *const u32, id.size) };
-    match s_height_sensor(&interface, indices.iter()) {
+    match s_{{NAME}}(&interface, indices.iter()) {
         Ok(packed) => {
             let ptr = unsafe { (cb)(packed.len()) };
             let slice = unsafe { std::slice::from_raw_parts_mut(ptr, packed.len()) };
@@ -36,7 +36,7 @@ pub fn handle_msg_get(interface : &{{NAME}}, id : BufferStruct, cb : SizeCallbac
 pub fn handle_msg_set(interface : &mut {{NAME}}, id : BufferStruct, data : BufferStruct) -> u32 {
     let indices = unsafe { std::slice::from_raw_parts(id.ptr as *const u32, id.size) };
     let slice = unsafe { std::slice::from_raw_parts(data.ptr, data.size) };
-    match d_height_sensor(interface, indices.iter(), slice) {
+    match d_{{NAME}}(interface, indices.iter(), slice) {
         Some(_) => {
             println!("Something went wrong!");
             return 1;
@@ -44,5 +44,15 @@ pub fn handle_msg_set(interface : &mut {{NAME}}, id : BufferStruct, data : Buffe
         None => {
             return 0; // success!
         }
+    }
+}
+
+pub fn get_pointer(interface : &{{NAME}}, id : BufferStruct) -> *const u8 {
+    let indices = unsafe { std::slice::from_raw_parts(id.ptr as *const u32, id.size) };
+    match p_{{NAME}}(interface, indices.iter()) {
+        Some(val) => {
+            return val;
+        },
+        None => return 0 as *const u8,
     }
 }

--- a/src/templates/source_cpp.template
+++ b/src/templates/source_cpp.template
@@ -3,6 +3,7 @@
 #include "{{MODEL_FILE}}"
 #include <nlohmann/json.hpp>
 #include <cstring>
+#include <optional>
 
 using nlohmann::json;
 typedef std::vector<uint8_t> bytes;
@@ -10,6 +11,7 @@ typedef std::vector<uint8_t> bytes;
 {{CLASS_DEFINITIONS}}
 {{SERIALIZATION}}
 {{DESERIALIZATION}}
+{{POINTER}}
 
 uint32_t handle_msg_get(const {{NAME}}& interface, BufferStruct id, SizeCallback cb) {
     bool error = false;
@@ -26,7 +28,7 @@ uint32_t handle_msg_get(const {{NAME}}& interface, BufferStruct id, SizeCallback
     return 0;
 }
 
-uint32_t handle_msg_set({{NAME}}& interface, BufferStruct id, BufferStruct data){
+uint32_t handle_msg_set({{NAME}}& interface, BufferStruct id, BufferStruct data) {
     std::vector<uint32_t> indices = std::vector<uint32_t>((uint32_t*)id.ptr, (uint32_t*)id.ptr + id.size);
     bytes buf = bytes(data.ptr, data.ptr + data.size); // not sure how not to copy here
     std::vector<uint32_t>::iterator begin = indices.begin();
@@ -35,4 +37,16 @@ uint32_t handle_msg_set({{NAME}}& interface, BufferStruct id, BufferStruct data)
         return 0;
     }
     return 1;
+}
+
+uint8_t* get_pointer({{NAME}}& interface, BufferStruct id) {
+    std::vector<uint32_t> indices = std::vector<uint32_t>((uint32_t*)id.ptr, (uint32_t*)id.ptr + id.size);
+    std::vector<uint32_t>::iterator begin = indices.begin();
+    std::vector<uint32_t>::iterator end   = indices.end();
+    auto opt = p_{{NAME}}(interface, begin, end);
+    if (opt.has_value()) {
+        return opt.value();
+    } else {
+        return nullptr;
+    }
 }

--- a/src/util_lib/affinetransform/Cargo.lock
+++ b/src/util_lib/affinetransform/Cargo.lock
@@ -7,8 +7,9 @@ name = "affinetransform"
 version = "0.1.0"
 dependencies = [
  "libc",
- "memoffset",
  "modellib",
+ "rmp-serde",
+ "rmpv",
 ]
 
 [[package]]
@@ -18,24 +19,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "data-buffer"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf536c3e706c4665b6643888d4f32201e05c09071b365f2180df465a02f8063"
+dependencies = [
+ "reinterpret",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
-name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "modellib"
 version = "0.1.0"
 dependencies = [
+ "data-buffer",
  "libc",
  "num-complex",
 ]
@@ -57,3 +65,46 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "reinterpret"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "318d0078beaf244bfa5dcd06174634339e41f3d21650ffcf70f4194d8852921a"
+
+[[package]]
+name = "rmp"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3eedffbfcc6a428f230c04baf8f59bd73c1781361e4286111fe900849aaddaf"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
+name = "rmpv"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de8813b3a2f95c5138fe5925bfb8784175d88d6bff059ba8ce090aa891319754"
+dependencies = [
+ "num-traits",
+ "rmp",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"

--- a/src/util_lib/affinetransform/Cargo.toml
+++ b/src/util_lib/affinetransform/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.0"
-memoffset = "0.5.4"
+rmp-serde = "1.0.0"
+rmpv = "1.0.0"
 
 [dependencies.modellib]
 path = "../../core/modellib"

--- a/src/util_lib/affinetransform/src/lib.rs
+++ b/src/util_lib/affinetransform/src/lib.rs
@@ -2,46 +2,42 @@
 // Rust Version
 
 
-#[macro_use]
-extern crate memoffset;
 extern crate modellib;
 extern crate libc;
 
+use libc::c_void;
+
+use modellib::BufferStruct;
+use modellib::SizeCallback;
 use modellib::BaseModel;
+use modellib::Framework;
 
 mod affine_transformation_interface;
 use affine_transformation_interface::*;
 
 #[repr(C)]
-pub struct affine_transformation {
-    // registered with RSIS
-    pub inputs : affine_transformation_in,
-    pub outputs : affine_transformation_out,
-    pub data : affine_transformation_data,
-    pub params : affine_transformation_params,
+pub struct affine_transformation_model {
+    pub intf : affine_transformation, // registered with RSIS
     // non viewable
 }
 
-impl affine_transformation {
-    pub fn new() -> affine_transformation {
-        affine_transformation {
-            inputs : affine_transformation_in::new(),
-            outputs : affine_transformation_out::new(),
-            data : affine_transformation_data::new(),
-            params : affine_transformation_params::new(),
+impl affine_transformation_model {
+    pub fn new() -> affine_transformation_model {
+        affine_transformation_model {
+            intf : affine_transformation::new(),
         }
     }
 }
 
-impl BaseModel for affine_transformation {
+impl BaseModel for affine_transformation_model {
     fn config(&mut self) -> bool {
         true
     }
-    fn init(&mut self) -> bool {
+    fn init(&mut self, _interface : &mut Box<dyn Framework>) -> bool {
         self.config()
     }
     fn step(&mut self) -> bool {
-        self.outputs.signal = self.inputs.signal * self.params.scaling + self.params.bias;
+        self.intf.outputs.signal = self.intf.inputs.signal * self.intf.params.scaling + self.intf.params.bias;
         true
     }
     fn pause(&mut self) -> bool {
@@ -50,4 +46,19 @@ impl BaseModel for affine_transformation {
     fn stop(&mut self) -> bool {
         true
     }
+    fn msg_get(&self, id : BufferStruct, cb : SizeCallback) -> u32 {
+        handle_msg_get(&self.intf, id, cb)
+    }
+    fn msg_set(&mut self, id : BufferStruct, data : BufferStruct) -> u32 {
+        handle_msg_set(&mut self.intf, id, data)
+    }
+    fn get_ptr(&self, id : BufferStruct) -> *const u8 {
+        get_pointer(&self.intf, id)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn create_model() -> *mut c_void {
+    let obj: Box<Box<dyn BaseModel + Send>> = Box::new(Box::new(affine_transformation_model::new()));
+    Box::into_raw(obj) as *mut Box<dyn BaseModel + Send> as *mut c_void
 }

--- a/tst/models/sensor_c++/src/.gitignore
+++ b/tst/models/sensor_c++/src/.gitignore
@@ -1,3 +1,3 @@
 height_sensor_interface.cxx
 height_sensor_interface.hxx
-
+*.meta

--- a/tst/models/sensor_c++/src/height_sensor.cxx
+++ b/tst/models/sensor_c++/src/height_sensor.cxx
@@ -32,6 +32,9 @@ uint32_t height_sensor_model::msg_get(BufferStruct id, SizeCallback cb) {
 uint32_t height_sensor_model::msg_set(BufferStruct id, BufferStruct data) {
     return handle_msg_set(intf, id, data);
 }
+uint8_t* height_sensor_model::get_ptr(BufferStruct id) {
+    return get_pointer(intf, id);
+}
 
 BaseModel* create_model() {
     return new height_sensor_model();

--- a/tst/models/sensor_c++/src/height_sensor.hxx
+++ b/tst/models/sensor_c++/src/height_sensor.hxx
@@ -17,6 +17,7 @@ public:
 
     uint32_t msg_get(BufferStruct id, SizeCallback cb);
     uint32_t msg_set(BufferStruct id, BufferStruct data);
+    uint8_t* get_ptr(BufferStruct id);
 
     height_sensor intf;
 };

--- a/tst/models/sensor_rust/src/lib.rs
+++ b/tst/models/sensor_rust/src/lib.rs
@@ -70,6 +70,9 @@ impl BaseModel for height_sensor_model {
     fn msg_set(&mut self, id : BufferStruct, data : BufferStruct) -> u32 {
         handle_msg_set(&mut self.intf, id, data)
     }
+    fn get_ptr(&self, id : BufferStruct) -> *const u8 {
+        get_pointer(&self.intf, id)
+    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
- Adds code autogeneration for exposing model ports as pointers
- Updates Rust & C++ interfaces for this interface
- Updates `affinetransform` to be in line with this and older updates
- Updates internal API for handling this data exchange
- Small changes