### PR TITLE
ndarray support

### DIFF
--- a/src/Model.jl
+++ b/src/Model.jl
@@ -234,7 +234,7 @@ function DataFrames.:describe(model::ModelReference, location::String; maxitems:
         if port.iscomposite
             push!(table, (elements[ii][1], "Struct", "", ""))
         else
-            push!(table, (elements[ii][1], "?", "$(model[location *"."*name])", "$(elements[ii][3])"))
+            push!(table, (elements[ii][1], port.type, "$(model[location *"."*name])", "$(elements[ii][3])"))
         end
     end
     if length(elements) > maxitems

--- a/src/Project.jl
+++ b/src/Project.jl
@@ -326,13 +326,20 @@ end
     clean!()
 Destroy build directory(s).
 """
-function clean!() :: Nothing
+function clean!(;target::String = "debug") :: Nothing
     if !isprojectloaded()
         println("No project loaded. Aborting")
     end
+    if target == "debug"
+        tt = DEBUG()
+    elseif target == "release"
+        tt = RELEASE()
+    else
+        throw(ArgumentError("target must be either [debug,release]"))
+    end
 
     cd(_loaded_project.directory)
-    rm(_builddir(_loaded_project.type); recursive=true)
+    rm(_builddir(_loaded_project.type, tt); recursive=true)
 end
 
 """

--- a/src/RSIS_Lib.jl
+++ b/src/RSIS_Lib.jl
@@ -264,6 +264,7 @@ function UnloadModelLib(name::String) :: Bool
     if name in keys(_modellibs)
         # unload all model instances
         for model in keys(_loaded_models)
+            @info "Deleting $(model)"
             delete!(_loaded_models, model)
         end
         _loaded_models = Dict{String, ModelInstance}()

--- a/src/templates/rust.template
+++ b/src/templates/rust.template
@@ -2,12 +2,15 @@
 
 extern crate modellib;
 extern crate libc;
+extern crate ndarray;
 extern crate rmp_serde;
 extern crate rmpv;
 
 use modellib::BufferStruct;
 use modellib::SizeCallback;
 use std::slice::Iter;
+use ndarray::prelude::*;
+use ndarray::Array;
 
 {{STRUCT_DEFINITIONS}}
 

--- a/src/templates/source_cpp.template
+++ b/src/templates/source_cpp.template
@@ -8,6 +8,30 @@
 using nlohmann::json;
 typedef std::vector<uint8_t> bytes;
 
+namespace std {
+    /**
+     * Custom support for complex types
+     */
+    void to_json(json& j, const std::complex<float>& obj) {
+        j = json { {"real", obj.real()}, {"imag", obj.imag()}};
+    }
+    void from_json(const json& j, std::complex<float>& obj) {
+        float r,i;
+        j.at("real").get_to(r);
+        j.at("imag").get_to(i);
+        obj.real(r); obj.imag(i);
+    }
+    void to_json(json& j, const std::complex<double>& obj) {
+        j = json { {"real", obj.real()}, {"imag", obj.imag()}};
+    }
+    void from_json(const json& j, std::complex<double>& obj) {
+        double r,i;
+        j.at("real").get_to(r);
+        j.at("imag").get_to(i);
+        obj.real(r); obj.imag(i);
+    }
+}
+
 {{CLASS_DEFINITIONS}}
 {{SERIALIZATION}}
 {{DESERIALIZATION}}

--- a/tst/models/sensor_c++/meson.build
+++ b/tst/models/sensor_c++/meson.build
@@ -1,6 +1,6 @@
 
 project('HeightSensor', ['c', 'cpp'],
-    version : '1.0.0',
+    version : '1.1.0',
     default_options : [
         'cpp_std=c++17'
     ])

--- a/tst/models/sensor_c++/src/height_sensor.cxx
+++ b/tst/models/sensor_c++/src/height_sensor.cxx
@@ -6,24 +6,24 @@ height_sensor_model::height_sensor_model() {
 
 height_sensor_model::~height_sensor_model() { }
 
-bool height_sensor_model::config() {
-    return true;
+ConfigStatus height_sensor_model::config() {
+    return ConfigStatus::OK;
 }
 
-bool height_sensor_model::init() {
-    return true;
+RuntimeStatus height_sensor_model::init() {
+    return RuntimeStatus::OK;
 }
 
-bool height_sensor_model::step() {
-    return true;
+RuntimeStatus height_sensor_model::step() {
+    return RuntimeStatus::OK;
 }
 
-bool height_sensor_model::pause() {
-    return true;
+RuntimeStatus height_sensor_model::pause() {
+    return RuntimeStatus::OK;
 }
 
-bool height_sensor_model::stop() {
-    return true;
+RuntimeStatus height_sensor_model::stop() {
+    return RuntimeStatus::OK;
 }
 
 uint32_t height_sensor_model::msg_get(BufferStruct id, SizeCallback cb) {

--- a/tst/models/sensor_c++/src/height_sensor.hxx
+++ b/tst/models/sensor_c++/src/height_sensor.hxx
@@ -1,6 +1,7 @@
 #ifndef __HEIGHT_SENSOR_HXX_
 #define __HEIGHT_SENSOR_HXX_
 
+#include <random>
 #include <BaseModel.hxx>
 #include "height_sensor_interface.hxx"
 
@@ -20,6 +21,8 @@ public:
     uint8_t* get_ptr(BufferStruct id);
 
     height_sensor intf;
+    std::mt19937 generator;
+    std::normal_distribution<double> dist;
 };
 
 

--- a/tst/models/sensor_c++/src/height_sensor.hxx
+++ b/tst/models/sensor_c++/src/height_sensor.hxx
@@ -9,11 +9,11 @@ public:
     height_sensor_model();
     virtual ~height_sensor_model();
 
-    bool config();
-    bool init();
-    bool step();
-    bool pause();
-    bool stop();
+    ConfigStatus config();
+    RuntimeStatus init();
+    RuntimeStatus step();
+    RuntimeStatus pause();
+    RuntimeStatus stop();
 
     uint32_t msg_get(BufferStruct id, SizeCallback cb);
     uint32_t msg_set(BufferStruct id, BufferStruct data);

--- a/tst/models/sensor_c++/src/height_sensor.yml
+++ b/tst/models/sensor_c++/src/height_sensor.yml
@@ -8,7 +8,10 @@ height_sensor_out:
     inrange: {type: Bool, value: false, desc: Measured height within range}
 
 height_sensor_data:
-    measurement: {type: Float64, value: 1.0, unit: m, desc: Actual sensor measurement}
+    measurement: {type: Float64, value: 1.0, unit: m, desc: Simulated sensor measurement}
+    line_voltages: {type: Int16, dims: [3, 2],
+        value: [0, 3, 4, 5, 6, 7], # 1D form required, makes implementation easy
+        desc: Simulated internal voltages, fixed point 8.8}
 
 height_sensor_params:
     limits: {type: Float64, dims: [2], value: [0.1, 0.8], unit: m, desc: Lower & upper range}

--- a/tst/models/sensor_rust/Cargo.toml
+++ b/tst/models/sensor_rust/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "sensor_rust"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 libc = "0.2.0"
-rand = "0.8.4"
+ndarray = { version = "0.15.4", features = ["serde"] }
+rand = "0.8.5"
 statrs = "0.15.0"
-rmp-serde = "1.0.0"
+rmp-serde = "1.1.0"
 rmpv = "1.0.0"
 
 [dependencies.modellib]

--- a/tst/models/sensor_rust/src/height_sensor.yml
+++ b/tst/models/sensor_rust/src/height_sensor.yml
@@ -9,10 +9,13 @@ height_sensor_out:
     inrange: {type: Bool, value: false, desc: Measured height within range}
 
 height_sensor_data:
-    measurement: {type: Float64, value: 1.0, unit: m, desc: Actual sensor measurement}
+    measurement: {type: Float64, value: 1.0, unit: m, desc: Simulated sensor measurement}
+    line_voltages: {type: Int16, dims: [3, 2],
+        value: [0, 3, 4, 5, 6, 7], # 1D form required, makes implementation easy
+        desc: Simulated internal voltages, fixed point 8.8}
 
 height_sensor_params:
-    limits: {type: Float64, dims: [2], value: [0.1, 0.8], unit: m, desc: Lower & upper range}
+    limits: {type: Float64, dims: [2], value: [0.1, 0.8], opts: "simplearray", unit: m, desc: Lower & upper range}
     noise: {type: Float64, value: 0.01, desc: Standard deviation of applied gaussian noise}
     stats_file: {type: String, value: sensor_info.txt, desc: Generated file}
 


### PR DESCRIPTION
Adds basic ndarray support to Rust & C++
- uses `ndarray` for multidimensional arrays in rust
   - the user can pass in an optional `simplearray` parameter to indicate that they want to actually generate a simple 1D array instead
- uses regular C arrays for multidimensional arrays in C++
   - I thought about using `std::array`, but this gets complicated with multidimensional things
- `describe` and `getindex` work as expected
- additional QOL changes, such as printing out which models were deleted when a model was unloaded
- Upgraded rust & C++ test models


BUGS:
- setting ndarrays does not work properly right now. Delaying till later