### PR TITLE
Soft real time

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [rsis]
-git-tree-sha1 = "e2199df25adbace56a3266f2a458716688aa0d0c"
+git-tree-sha1 = "a23e9bf833f317775b0f3fc1adcf4500e778d2fd"
 
     [[rsis.download]]
-    sha256 = "9be0d335e7c0f3b9d5eb433bb670b5b7f5b69006723c27f369135680b9aac5b9"
+    sha256 = "8ef8429a0100c682633041c7a5acecedb547d293f3221328cebb620fc54a75bd"
     url = "file:/home/kelly/rsis/rsis.tar.gz"

--- a/src/RSIS.jl
+++ b/src/RSIS.jl
@@ -32,7 +32,7 @@ end
 
 include("RSIS_Lib.jl")
 using .MLibrary
-export getscheduler
+export getscheduler, schedulerparam!
 export newmodel, getmodel, deletemodel!, listmodels, listmodelsbytag, listlibraries
 export ModelInstance
 export simstatus, SchedulerState

--- a/src/RSIS_Lib.jl
+++ b/src/RSIS_Lib.jl
@@ -4,7 +4,8 @@ using Base: Int32, _getmeta
 
 export LoadLibrary, UnloadLibrary, InitLibrary, ShutdownLibrary
 export newmodel, deletemodel!, getmodel, listmodels, listmodelsbytag, listlibraries
-export getscheduler, initscheduler, stepscheduler, endscheduler, addthread, schedulemodel, createconnection
+export getscheduler, initscheduler, stepscheduler, endscheduler, schedulerparam!
+export addthread, schedulemodel, createconnection
 export LoadModelLib, UnloadModelLib, _libraryprefix, _libraryextension
 export _getmodelinstance, _meta_get, _meta_set, _get_ptr
 export ModelInstance, ModelReference
@@ -50,6 +51,7 @@ mutable struct LibFuncs
     s_getmessage
     s_getstate
     s_getschedulername
+    s_configscheduler
     function LibFuncs(lib)
         new(Libdl.dlsym(lib, :library_initialize),
             Libdl.dlsym(lib, :library_shutdown),
@@ -63,7 +65,8 @@ mutable struct LibFuncs
             Libdl.dlsym(lib, :end_scheduler),
             Libdl.dlsym(lib, :get_message),
             Libdl.dlsym(lib, :get_scheduler_state),
-            Libdl.dlsym(lib, :get_scheduler_name))
+            Libdl.dlsym(lib, :get_scheduler_name),
+            Libdl.dlsym(lib, :config_scheduler))
     end
 end
 
@@ -447,5 +450,13 @@ function simstatus() :: SchedulerState
     return SchedulerState(stat);
 end
 
+function schedulerparam!(name::String, parameter) :: Nothing
+    data = "SRT"
+    bufdata = BufferData(pointer(data), length(data))
+    stat = ccall(_sym.s_configscheduler, UInt32, (BufferData,), bufdata);
+    if stat != 0
+        throw(ErrorException("Call to `config_scheduler` in library failed"))
+    end
+end
 
 end

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 libc = "0.2.0"
 data-buffer = "0.8.0"
+rmp-serde = "1.1.0"
 
 [dependencies.modellib]
 git = "https://github.com/Sinfaen/rsis-app-interface"

--- a/src/core/src/scheduler.rs
+++ b/src/core/src/scheduler.rs
@@ -22,7 +22,7 @@ pub trait Scheduler {
     fn add_model(&mut self, model: Box<Box<dyn BaseModel + Send>>, thread: usize, divisor: i64, offset: i64) -> *mut c_void;
     fn get_num_threads(&self) -> i32;
 
-    fn config(&mut self, json : String) -> i32;
+    fn config(&mut self, key : &[u8], value : &[u8]) -> Option<i32>;
     fn init(&mut self) -> i32;
     fn step(&mut self, steps: u64) -> i32;
     fn pause(&mut self) -> i32;

--- a/src/core/src/scheduler.rs
+++ b/src/core/src/scheduler.rs
@@ -22,7 +22,7 @@ pub trait Scheduler {
     fn add_model(&mut self, model: Box<Box<dyn BaseModel + Send>>, thread: usize, divisor: i64, offset: i64) -> *mut c_void;
     fn get_num_threads(&self) -> i32;
 
-    fn config(&mut self, toml : String) -> i32;
+    fn config(&mut self, json : String) -> i32;
     fn init(&mut self) -> i32;
     fn step(&mut self, steps: u64) -> i32;
     fn pause(&mut self) -> i32;


### PR DESCRIPTION
Adds the ability to configure schedulers with arbitrary messagepack data, in a key value format.

Adds the `srt` option to the NRTScheduler, which then adds in an attempt to simulate real time via the sleep functionality from rust time.

Small updates here and there for ease of use, information. Additional removal of `unwrap`

Related to https://github.com/Sinfaen/RSIS/issues/19